### PR TITLE
Enable Auto-Approval & Merge for Dependency PRs from Bots

### DIFF
--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -1,0 +1,26 @@
+name: Auto Approve and Merge for Dependency Bots
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto approve PR
+        uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+  auto-merge:
+    needs: auto-approve
+    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
This workflow automates the approval and merge process for pull requests created by Dependabot and Depfu bots. It ensures dependency updates are merged faster, improving security and keeping the project up to date.

It uses:
- `hmarr/auto-approve-action` to simulate approval.
- `peter-evans/enable-pull-request-automerge` to complete the merge automatically (if checks pass).