### PR TITLE
Fix AutoMapper registration

### DIFF
--- a/ACGSS.Web/Program.cs
+++ b/ACGSS.Web/Program.cs
@@ -22,7 +22,10 @@ builder.Services.AddDbContext<EFContext>(options =>
 
 builder.Services.SetupUnitOfWork();
 
-builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly().GetReferencedAssemblies().Select(Assembly.Load));
+builder.Services.AddAutoMapper(
+    Assembly.GetExecutingAssembly().GetReferencedAssemblies()
+        .Select(Assembly.Load)
+        .ToArray());
 
 builder.Services.AddScoped<IUserService, UserService>();
 


### PR DESCRIPTION
## Summary
- fix the argument passed to `AddAutoMapper` so it expects an array of assemblies

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d356b1de483238863e35d9fdaa870