### PR TITLE
fix: add multiple assemblies, passing Assembly objects

### DIFF
--- a/ACGSS.Web/Program.cs
+++ b/ACGSS.Web/Program.cs
@@ -21,14 +21,8 @@ builder.Services.AddDbContext<EFContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("EFContext")));
 
 builder.Services.SetupUnitOfWork();
-
-builder.Services.AddAutoMapper(
-    Assembly.GetExecutingAssembly().GetReferencedAssemblies()
-        .Select(Assembly.Load)
-        .ToArray());
-
+builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
 builder.Services.AddScoped<IUserService, UserService>();
-
 builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("EmailSettings"));
 builder.Services.AddTransient<IEmailSenderService, EmailSender>();
 


### PR DESCRIPTION
The build failed due to this error in ACGSS.Web/Program.cs at line 26:

> error CS1503: Argument 2: cannot convert from 'System.Reflection.Assembly[]' to 'System.Action<AutoMapper.IMapperConfigurationExpression>'

The AddAutoMapper extension expects a params array of assemblies or an Action<IMapperConfigurationExpression>, not the result of Select(Assembly.Load) on referenced assemblies.