### PR TITLE
Fix Node.js 20 deprecation warning in GitHub Actions

### DIFF
--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -1,5 +1,8 @@
 name: Auto Approve and Merge for Dependency Bots
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,9 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 10.0.100
     - name: Restore dependencies

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [ "main" ]
@@ -15,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.100
     - name: Restore dependencies


### PR DESCRIPTION
This PR addresses the deprecation warning for Node.js 20 actions in GitHub Actions. It sets the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to `true` in both `.github/workflows/dotnet.yml` and `.github/workflows/auto-approve-dependency-bots.yml`. Additionally, it upgrades the official GitHub actions `actions/checkout` and `actions/setup-dotnet` to version 4 in the `.NET` workflow.

---
*PR created automatically by Jules for task [5589572455717048277](https://jules.google.com/task/5589572455717048277) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies to their latest major versions for improved compatibility and security.
  * Configured automated build environments to use Node.js 24 for enhanced tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->